### PR TITLE
Make COVERALLS_REPO_TOKEN secret available

### DIFF
--- a/.github/workflows/smalltalk-ci.yml
+++ b/.github/workflows/smalltalk-ci.yml
@@ -22,3 +22,5 @@ jobs:
     - run: smalltalkci -s ${{ steps.smalltalkci.outputs.smalltalk-version }}
       shell: bash
       timeout-minutes: 15
+      env:
+        COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}


### PR DESCRIPTION
This allows smalltalkCI to upload coverage reports to Coveralls from GitHub actions (example is at [1]). Unfortunately, Coveralls does not seem to support GitHub actions properly yet (the integration is limited to lcov files), but using a repo_token (see [2]) it is possible to upload coverage results in Coveralls' raw JSON format.

[1] https://coveralls.io/jobs/65929250
[2] https://docs.coveralls.io/api-introduction