### PR TITLE
Ci: add coverage

### DIFF
--- a/.coverage.ston
+++ b/.coverage.ston
@@ -13,7 +13,7 @@ SmalltalkCISpec {
   ],
   #testing : {
     #coverage : {
-      #categories : [ 'Algernon', 'BaselineOfAlgernon' ]
+      #categories : [ 'Algernon' ]
     },
     #exclude : {
       #categories : [ 'BaselineOfAlgernonTests' ]

--- a/.coverage.ston
+++ b/.coverage.ston
@@ -14,6 +14,9 @@ SmalltalkCISpec {
   #testing : {
     #coverage : {
       #categories : [ 'AlgernonTests' ]
+    },
+    #exclude : {
+      #categories : [ 'BaselineOfAlgernonTests' ]
     }
   }
 }

--- a/.coverage.ston
+++ b/.coverage.ston
@@ -13,7 +13,7 @@ SmalltalkCISpec {
   ],
   #testing : {
     #coverage : {
-      #categories : [ 'AlgernonTests' ]
+      #packages : [ 'Algernon.*', 'BaselineOfAlgernon.*' ]
     },
     #exclude : {
       #categories : [ 'BaselineOfAlgernonTests' ]

--- a/.coverage.ston
+++ b/.coverage.ston
@@ -1,0 +1,20 @@
+SmalltalkCISpec {
+  #loading : [
+    SCIMetacelloLoadSpec {
+      #baseline : 'Algernon',
+      #directory : 'packages',
+      #load : 'Tests',
+      #platforms : [ #squeak ],
+      #useLatestMetacello : true
+    }
+  ],
+  #preLoading : [
+    'scripts/preLoading.st'
+  ],
+  #testing : {
+    #coverage : {
+      #categories : [ 'AlgernonTests' ]
+    }
+  }
+}
+

--- a/.coverage.ston
+++ b/.coverage.ston
@@ -13,7 +13,7 @@ SmalltalkCISpec {
   ],
   #testing : {
     #coverage : {
-      #packages : [ 'Algernon.*', 'BaselineOfAlgernon.*' ]
+      #categories : [ 'Algernon', 'BaselineOfAlgernon' ]
     },
     #exclude : {
       #categories : [ 'BaselineOfAlgernonTests' ]

--- a/.github/workflows/coverage-reporter.yml
+++ b/.github/workflows/coverage-reporter.yml
@@ -5,13 +5,15 @@ jobs:
   coverage:
     name: Coverage Report
     runs-on: ubuntu-latest
+    env:
+      ST_IMAGE: Squeak64-trunk
     steps:
       - uses: actions/checkout@v2
       - uses: hpi-swa/setup-smalltalkCI@v1
         id: smalltalkci
         with:
-          smalltalk-image: "Squeak64-trunk"
-      - run: smalltalkci -s ${{ steps.smalltalkci.outputs.smalltalk-version }} ./.coverage.ston
+          smalltalk-image: ${{ ST_IMAGE }}
+      - run: smalltalkci -s ${{ ST_IMAGE }} ./.coverage.ston
         shell: bash
         timeout-minutes: 15
         env:

--- a/.github/workflows/coverage-reporter.yml
+++ b/.github/workflows/coverage-reporter.yml
@@ -1,0 +1,23 @@
+name: Coverage Reporter
+# Only trigger, when the tests succeeded
+on:
+  workflow_run:
+    workflows: ["smalltalkCI"]
+    types:
+      - completed
+
+jobs:
+  coverage:
+    name: Coverage Report
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: hpi-swa/setup-smalltalkCI@v1
+        id: smalltalkci
+        with:
+          smalltalk-image: "Squeak64-trunk"
+      - run: smalltalkci -s ${{ steps.smalltalkci.outputs.smalltalk-version }} ./.coverage.ston
+        shell: bash
+        timeout-minutes: 15
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/coverage-reporter.yml
+++ b/.github/workflows/coverage-reporter.yml
@@ -1,10 +1,5 @@
 name: Coverage Reporter
-# Only trigger, when the tests succeeded
-on:
-  workflow_run:
-    workflows: ["smalltalkCI"]
-    types:
-      - completed
+on: [push]
 
 jobs:
   coverage:

--- a/.github/workflows/coverage-reporter.yml
+++ b/.github/workflows/coverage-reporter.yml
@@ -12,8 +12,8 @@ jobs:
       - uses: hpi-swa/setup-smalltalkCI@v1
         id: smalltalkci
         with:
-          smalltalk-image: ${{ ST_IMAGE }}
-      - run: smalltalkci -s ${{ ST_IMAGE }} ./.coverage.ston
+          smalltalk-image: ${{ env.ST_IMAGE }}
+      - run: smalltalkci -s ${{ env.ST_IMAGE }} ./.coverage.ston
         shell: bash
         timeout-minutes: 15
         env:

--- a/.github/workflows/smalltalk-ci.yml
+++ b/.github/workflows/smalltalk-ci.yml
@@ -19,7 +19,7 @@ jobs:
         id: smalltalkci
         with:
           smalltalk-image: ${{ matrix.smalltalk }}
-      - run: smalltalkci -s ${{ steps.smalltalkci.outputs.smalltalk-version }}
+      - run: smalltalkci -s ${{ matrix.smalltalk }}
         shell: bash
         timeout-minutes: 15
         env:

--- a/.github/workflows/smalltalk-ci.yml
+++ b/.github/workflows/smalltalk-ci.yml
@@ -5,7 +5,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         smalltalk:
           - Squeak64-5.3
           - Squeak64-5.2
@@ -14,13 +14,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.smalltalk }} on ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
-    - uses: hpi-swa/setup-smalltalkCI@v1
-      id: smalltalkci
-      with:
-        smalltalk-image: ${{ matrix.smalltalk }}
-    - run: smalltalkci -s ${{ steps.smalltalkci.outputs.smalltalk-version }}
-      shell: bash
-      timeout-minutes: 15
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v2
+      - uses: hpi-swa/setup-smalltalkCI@v1
+        id: smalltalkci
+        with:
+          smalltalk-image: ${{ matrix.smalltalk }}
+      - run: smalltalkci -s ${{ steps.smalltalkci.outputs.smalltalk-version }}
+        shell: bash
+        timeout-minutes: 15
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/smalltalk-ci.yml
+++ b/.github/workflows/smalltalk-ci.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: hpi-swa/setup-smalltalkCI@v1
       id: smalltalkci
       with:
-        smalltalk-version: ${{ matrix.smalltalk }}
+        smalltalk-image: ${{ matrix.smalltalk }}
     - run: smalltalkci -s ${{ steps.smalltalkci.outputs.smalltalk-version }}
       shell: bash
       timeout-minutes: 15


### PR DESCRIPTION
Because of the BaselineTests, coverage has been disabled.
This PR removes the deprecated attribute `smalltalk-version` in the workflow and adds a new workflow that only executes AlgernonTests and sends the coverage to coveralls.

(I hope that we can get the coveralls bot to comment the coverage on PRs, but I think an SWT-admin has to change that)