### PR TITLE
Fix CI to use development branch again

### DIFF
--- a/packages/BaselineOfAlgernonTests.package/BOALGTest.class/instance/setUp.st
+++ b/packages/BaselineOfAlgernonTests.package/BOALGTest.class/instance/setUp.st
@@ -5,5 +5,5 @@ setUp
 	self metacelloInstance: 
 	(Metacello new
    	 	baseline: 'Algernon';
-  		repository: 'github://HPI-SWA-Teaching/Algernon-Launcher:feat%2Freload-classes/packages';
+  		repository: 'github://HPI-SWA-Teaching/Algernon-Launcher:development/packages';
    	 	onConflict: [:ex | ex allow])

--- a/packages/BaselineOfAlgernonTests.package/BOALGTest.class/methodProperties.json
+++ b/packages/BaselineOfAlgernonTests.package/BOALGTest.class/methodProperties.json
@@ -4,6 +4,6 @@
 	"instance" : {
 		"metacelloInstance" : "lm 5/9/2021 19:13",
 		"metacelloInstance:" : "lm 5/9/2021 19:13",
-		"setUp" : "b 6/10/2021 15:04",
+		"setUp" : "b 6/10/2021 15:34",
 		"tearDown" : "b 6/10/2021 15:09",
 		"testEnableAfterInstall" : "lm 5/9/2021 19:25" } }


### PR DESCRIPTION
We had to do this because development and feat/reload-classes were incompatible, but we are denied to merge when tests won't pass.

Co-authored-by: Oliver Heß <oliver.hess@student.hpi.de>