### PR TITLE
Don't cancel other CI runs once one fails

### DIFF
--- a/.github/workflows/smalltalk-ci.yml
+++ b/.github/workflows/smalltalk-ci.yml
@@ -4,6 +4,7 @@ on: [push]
 jobs:
   test:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         smalltalk:


### PR DESCRIPTION
This is what I meant some time back. We could put this into #228 if we don't want another commit too

Reference: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast